### PR TITLE
Fix Maven coordinates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,15 +9,15 @@ This library provides helpers for integrating [graphql-java](https://github.com/
 ### Maven
 ```
     <dependency>
-      <groupId>com.newrelic</groupId>
-      <artifactId>newrelic-graphql-java-core</artifactId>
+      <groupId>com.newrelic.graphql</groupId>
+      <artifactId>core</artifactId>
       <version>0.1.0</version>
     </dependency>
 ```
 
 ### Gradle
 ```
-compile("com.newrelic:newrelic-graphql-java-core:0.1.0")
+compile("com.newrelic.graphql:core:0.1.0")
 ```
 
 ## Usage

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-group = com.newrelic
+group = com.newrelic.graphql
 version = 0.1.0-SNAPSHOT
 
 jdk.version=1.8

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'newrelic-graphql-java-core'
+rootProject.name = 'core'


### PR DESCRIPTION
Realized in looking to our next step of publishing to Maven Central that I'd set our group here as `com.newrelic` while other New Relic projects use a more specific group (like `com.newrelic.telemetry`.