### PR TITLE
Workflow updates to publish on master merge

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,11 @@
-# This workflow will build a Java project with Gradle
-# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
-
-name: Java CI with Gradle
+name: Build, Publish, and Archive
 
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
-  build:
+  build_and_publish:
 
     runs-on: ubuntu-latest
 
@@ -22,8 +17,14 @@ jobs:
         java-version: 1.8
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew build javadoc
+    - name: Build and Publish
+      env:
+        SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+        SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+        ORG_GRADLE_PROJECT_signingKey: ${{ secrets.SIGNING_KEY }}
+        ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
+        ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
+      run: ./gradlew build publish
     - name: Archive libs
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,31 @@
+name: Build and Archive
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build javadoc
+    - name: Archive libs
+      uses: actions/upload-artifact@v1
+      with:
+        name: libs
+        path: build/libs
+    - name: Archive docs
+      uses: actions/upload-artifact@v1
+      with:
+        name: docs
+        path: build/docs/javadoc


### PR DESCRIPTION
Splits out our workflows into separate ones for PR and master merge. Wires in to invoke publish on master merge, which will properly choose to send either a snapshot or a release to staging based on the version.