### PR TITLE
Fix scalars serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Coming soon
+- Fix for using our scalars with input mapped object
 
 ## [0.1.0] - 2020-06-18
 - Initial full release :tada:

--- a/src/main/java/com/newrelic/graphql/schema/scalars/DateTime.java
+++ b/src/main/java/com/newrelic/graphql/schema/scalars/DateTime.java
@@ -4,7 +4,10 @@
  */
 package com.newrelic.graphql.schema.scalars;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.Map;
 
 /**
  * ISO-8601 compliant custom scalar. Expects String inputs, converts to wrap a {@code ZonedDateTime}
@@ -16,6 +19,40 @@ public class DateTime {
   /** @param dateTime Construct with a specific datetime */
   public DateTime(ZonedDateTime dateTime) {
     this.dateTime = dateTime;
+  }
+
+  // Support for serialization from instances of our own type
+  @JsonCreator
+  private DateTime(Map<String, Object> props) {
+    this(rawValueFromProps(props));
+  }
+
+  protected static ZonedDateTime rawValueFromProps(Map<String, Object> props) {
+    Map<String, Object> value = cast(props.get("dateTime"));
+    if (value == null) {
+      throw new IllegalArgumentException("Can't deserialize from properties missing 'dateTime'");
+    }
+
+    Map<String, Object> zone = cast(value.get("zone"));
+    if (zone == null) {
+      throw new IllegalArgumentException(
+          "Can't deserialize from properties missing 'dateTime.zone'");
+    }
+
+    return ZonedDateTime.of(
+        (Integer) value.get("year"),
+        (Integer) value.get("monthValue"),
+        (Integer) value.get("dayOfMonth"),
+        (Integer) value.get("hour"),
+        (Integer) value.get("minute"),
+        (Integer) value.get("second"),
+        (Integer) value.get("nano"),
+        ZoneId.of((String) zone.get("id")));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T cast(Object rawValue) {
+    return (T) rawValue;
   }
 
   /** @return Wrapped datetime object */

--- a/src/main/java/com/newrelic/graphql/schema/scalars/EpochMilliseconds.java
+++ b/src/main/java/com/newrelic/graphql/schema/scalars/EpochMilliseconds.java
@@ -4,7 +4,9 @@
  */
 package com.newrelic.graphql.schema.scalars;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import graphql.schema.Coercing;
+import java.util.Map;
 
 /** Custom scalar representing a specific number of milliseconds since epoch */
 public class EpochMilliseconds extends InstantWrapper<EpochMilliseconds> {
@@ -12,6 +14,12 @@ public class EpochMilliseconds extends InstantWrapper<EpochMilliseconds> {
   /** @param value Incoming number of milliseconds since epoch */
   public EpochMilliseconds(Number value) {
     super(value, (n) -> buildInstant(n, 6));
+  }
+
+  // Support for serialization from instances of our own type
+  @JsonCreator
+  private EpochMilliseconds(Map<String, Object> props) {
+    this(rawValueFromProps(props));
   }
 
   /** @return Coercion instance for converting numbers to EpochMilliseconds */

--- a/src/main/java/com/newrelic/graphql/schema/scalars/EpochSeconds.java
+++ b/src/main/java/com/newrelic/graphql/schema/scalars/EpochSeconds.java
@@ -4,7 +4,9 @@
  */
 package com.newrelic.graphql.schema.scalars;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import graphql.schema.Coercing;
+import java.util.Map;
 
 /** Custom scalar representing a specific number of seconds since epoch */
 public class EpochSeconds extends InstantWrapper<EpochSeconds> {
@@ -12,6 +14,12 @@ public class EpochSeconds extends InstantWrapper<EpochSeconds> {
   /** @param value Incoming number of seconds since epoch */
   public EpochSeconds(Number value) {
     super(value, (n) -> buildInstant(n, 9));
+  }
+
+  // Support for serialization from instances of our own type
+  @JsonCreator
+  private EpochSeconds(Map<String, Object> props) {
+    this(rawValueFromProps(props));
   }
 
   /** @return Coercion instance for converting numbers to EpochSeconds */

--- a/src/main/java/com/newrelic/graphql/schema/scalars/Milliseconds.java
+++ b/src/main/java/com/newrelic/graphql/schema/scalars/Milliseconds.java
@@ -4,7 +4,9 @@
  */
 package com.newrelic.graphql.schema.scalars;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import graphql.schema.Coercing;
+import java.util.Map;
 
 /** Custom scalar representing a specific length of time in milliseconds */
 public class Milliseconds extends DurationWrapper<Milliseconds> {
@@ -12,6 +14,12 @@ public class Milliseconds extends DurationWrapper<Milliseconds> {
   /** @param value Number of milliseconds */
   public Milliseconds(Number value) {
     super(value, (n) -> buildDuration(n, 6));
+  }
+
+  // Support for serialization from instances of our own type
+  @JsonCreator
+  private Milliseconds(Map<String, Object> props) {
+    super(rawValueFromProps(props), (n) -> buildDuration(rawValueFromProps(props), 6));
   }
 
   /** @return Coercion instance for converting numbers to Milliseconds */

--- a/src/main/java/com/newrelic/graphql/schema/scalars/Minutes.java
+++ b/src/main/java/com/newrelic/graphql/schema/scalars/Minutes.java
@@ -4,8 +4,10 @@
  */
 package com.newrelic.graphql.schema.scalars;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import graphql.schema.Coercing;
 import java.time.Duration;
+import java.util.Map;
 
 /** Custom scalar representing a specific length of time in minutes */
 public class Minutes extends DurationWrapper<Minutes> {
@@ -13,6 +15,12 @@ public class Minutes extends DurationWrapper<Minutes> {
   /** @param value Number of minutes */
   public Minutes(Number value) {
     super(value, (n) -> Duration.ofMinutes(n.longValue()));
+  }
+
+  // Support for serialization from instances of our own type
+  @JsonCreator
+  private Minutes(Map<String, Object> props) {
+    this(rawValueFromProps(props));
   }
 
   /** @return Coercion instance for converting numbers to Minutes */

--- a/src/main/java/com/newrelic/graphql/schema/scalars/NumberCoercing.java
+++ b/src/main/java/com/newrelic/graphql/schema/scalars/NumberCoercing.java
@@ -13,6 +13,7 @@ import graphql.schema.CoercingParseValueException;
 import graphql.schema.CoercingSerializeException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.util.Map;
 import java.util.Objects;
 
 /**
@@ -114,6 +115,16 @@ public abstract class NumberCoercing<T extends NumberCoercing.NumberWrapper>
         dec = new BigDecimal(n.doubleValue());
       }
       return dec;
+    }
+
+    // Support method for deserialization from instances of our own type
+    protected static Number rawValueFromProps(Map<String, Object> props) {
+      Number value = (Number) props.get("rawValue");
+      if (value == null) {
+        throw new IllegalArgumentException("Can't deserialize from properties missing 'rawValue'");
+      }
+
+      return value;
     }
 
     @Override

--- a/src/main/java/com/newrelic/graphql/schema/scalars/Seconds.java
+++ b/src/main/java/com/newrelic/graphql/schema/scalars/Seconds.java
@@ -4,7 +4,9 @@
  */
 package com.newrelic.graphql.schema.scalars;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import graphql.schema.Coercing;
+import java.util.Map;
 
 /** Custom scalar representing a specific length of time in seconds */
 public class Seconds extends DurationWrapper<Seconds> {
@@ -12,6 +14,12 @@ public class Seconds extends DurationWrapper<Seconds> {
   /** @param value Number of seconds */
   public Seconds(Number value) {
     super(value, (n) -> buildDuration(n, 9));
+  }
+
+  // Support for serialization from instances of our own type
+  @JsonCreator
+  private Seconds(Map<String, Object> props) {
+    this(rawValueFromProps(props));
   }
 
   /** @return Coercion instance for converting numbers to Seconds */

--- a/src/test/java/com/newrelic/graphql/schema/scalars/DateTimeTest.java
+++ b/src/test/java/com/newrelic/graphql/schema/scalars/DateTimeTest.java
@@ -8,7 +8,16 @@ import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.newrelic.graphql.mapper.GraphQLInputMapper;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLList;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.junit.Test;
 
 public class DateTimeTest {
@@ -16,6 +25,8 @@ public class DateTimeTest {
   private static final String zonedString = "1978-09-01T10:15:30-09:00";
   private static final ZonedDateTime zonedExample = ZonedDateTime.parse(zonedString);
   private static final DateTime dateTime = new DateTime(zonedExample);
+  private final GraphQLInputMapper mapper =
+      new GraphQLInputMapper(this.getClass().getPackage().getName());
 
   @Test
   public void checkToString() {
@@ -36,5 +47,67 @@ public class DateTimeTest {
   @Test
   public void checkHashCode() {
     assertEquals(dateTime.hashCode(), new DateTime(zonedExample).hashCode());
+  }
+
+  @Test
+  public void convertToScalarFromInstanceOfSelf() throws ClassNotFoundException {
+    Object actual = mapper.convert(new DateTime(zonedExample), PredefinedScalars.DateTime);
+
+    assertEquals(new DateTime(zonedExample), actual);
+  }
+
+  @Test
+  public void convertToContainerObjectFromInstanceOfSelf() throws ClassNotFoundException {
+    HashMap<String, Object> raw = new HashMap<>();
+    raw.put("dateTime", new DateTime(zonedExample));
+    Object actual = mapper.convert(raw, DateTimeContainer.GraphQLType);
+
+    assertEquals(new DateTimeContainer(new DateTime(zonedExample)), actual);
+  }
+
+  @Test
+  public void convertToListOfContainerObjectsFromInstanceOfSelf() throws ClassNotFoundException {
+    Map<String, Object> item = new HashMap<>();
+    item.put("dateTime", new DateTime(zonedExample));
+
+    List<Map<String, Object>> raw = new ArrayList<>();
+    raw.add(item);
+
+    Object actual = mapper.convert(raw, new GraphQLList(DateTimeContainer.GraphQLType));
+
+    List<DateTimeContainer> expected = new ArrayList<>();
+    expected.add(new DateTimeContainer(new DateTime(zonedExample)));
+    assertEquals(expected, actual);
+  }
+}
+
+class DateTimeContainer {
+  public final DateTime dateTime;
+
+  public static final GraphQLInputObjectType GraphQLType =
+      GraphQLInputObjectType.newInputObject().name("DateTimeContainer").build();
+
+  public DateTimeContainer(@JsonProperty("dateTime") DateTime dateTime) {
+    this.dateTime = dateTime;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    DateTimeContainer that = (DateTimeContainer) o;
+
+    return Objects.equals(dateTime, that.dateTime);
+  }
+
+  @Override
+  public int hashCode() {
+    return dateTime != null ? dateTime.hashCode() : 0;
+  }
+
+  @Override
+  public String toString() {
+    return "DateTimeContainer{" + "dateTime=" + dateTime + '}';
   }
 }

--- a/src/test/java/com/newrelic/graphql/schema/scalars/EpochMillisecondsTest.java
+++ b/src/test/java/com/newrelic/graphql/schema/scalars/EpochMillisecondsTest.java
@@ -8,12 +8,23 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.newrelic.graphql.mapper.GraphQLInputMapper;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLList;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.junit.Test;
 
 public class EpochMillisecondsTest {
 
   private final EpochMilliseconds millis = new EpochMilliseconds(1L);
+  private final GraphQLInputMapper mapper =
+      new GraphQLInputMapper(this.getClass().getPackage().getName());
 
   @Test
   public void testEquals() {
@@ -38,5 +49,68 @@ public class EpochMillisecondsTest {
   public void floatingPointDuration() {
     EpochMilliseconds floating = new EpochMilliseconds(1.234);
     assertEquals(Instant.ofEpochSecond(0, 1233999L), floating.getInstant());
+  }
+
+  @Test
+  public void convertToScalarFromInstanceOfSelf() throws ClassNotFoundException {
+    Object actual =
+        mapper.convert(new EpochMilliseconds(1000), PredefinedScalars.EpochMilliseconds);
+
+    assertEquals(new EpochMilliseconds(1000), actual);
+  }
+
+  @Test
+  public void convertToContainerObjectFromInstanceOfSelf() throws ClassNotFoundException {
+    HashMap<String, Object> raw = new HashMap<>();
+    raw.put("millis", new EpochMilliseconds(1000));
+    Object actual = mapper.convert(raw, EpochMillisecondsContainer.GraphQLType);
+
+    assertEquals(new EpochMillisecondsContainer(new EpochMilliseconds(1000)), actual);
+  }
+
+  @Test
+  public void convertToListOfContainerObjectsFromInstanceOfSelf() throws ClassNotFoundException {
+    Map<String, Object> item = new HashMap<>();
+    item.put("millis", new EpochMilliseconds(1000));
+
+    List<Map<String, Object>> raw = new ArrayList<>();
+    raw.add(item);
+
+    Object actual = mapper.convert(raw, new GraphQLList(EpochMillisecondsContainer.GraphQLType));
+
+    List<EpochMillisecondsContainer> expected = new ArrayList<>();
+    expected.add(new EpochMillisecondsContainer(new EpochMilliseconds(1000)));
+    assertEquals(expected, actual);
+  }
+}
+
+class EpochMillisecondsContainer {
+  public final EpochMilliseconds millis;
+
+  public static final GraphQLInputObjectType GraphQLType =
+      GraphQLInputObjectType.newInputObject().name("EpochMillisecondsContainer").build();
+
+  public EpochMillisecondsContainer(@JsonProperty("millis") EpochMilliseconds millis) {
+    this.millis = millis;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    EpochMillisecondsContainer that = (EpochMillisecondsContainer) o;
+
+    return Objects.equals(millis, that.millis);
+  }
+
+  @Override
+  public int hashCode() {
+    return millis != null ? millis.hashCode() : 0;
+  }
+
+  @Override
+  public String toString() {
+    return "EpochMillisecondsContainer{" + "millis=" + millis + '}';
   }
 }

--- a/src/test/java/com/newrelic/graphql/schema/scalars/EpochSecondsTest.java
+++ b/src/test/java/com/newrelic/graphql/schema/scalars/EpochSecondsTest.java
@@ -8,12 +8,23 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.newrelic.graphql.mapper.GraphQLInputMapper;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLList;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.junit.Test;
 
 public class EpochSecondsTest {
 
   private final EpochSeconds seconds = new EpochSeconds(1L);
+  private final GraphQLInputMapper mapper =
+      new GraphQLInputMapper(this.getClass().getPackage().getName());
 
   @Test
   public void testEquals() {
@@ -37,5 +48,67 @@ public class EpochSecondsTest {
   public void floatingPointDuration() {
     EpochSeconds floating = new EpochSeconds(1.234);
     assertEquals(Instant.ofEpochSecond(1, 233999999L), floating.getInstant());
+  }
+
+  @Test
+  public void convertToScalarFromInstanceOfSelf() throws ClassNotFoundException {
+    Object actual = mapper.convert(new EpochSeconds(1000), PredefinedScalars.EpochSeconds);
+
+    assertEquals(new EpochSeconds(1000), actual);
+  }
+
+  @Test
+  public void convertToContainerObjectFromInstanceOfSelf() throws ClassNotFoundException {
+    HashMap<String, Object> raw = new HashMap<>();
+    raw.put("seconds", new EpochSeconds(1000));
+    Object actual = mapper.convert(raw, EpochSecondsContainer.GraphQLType);
+
+    assertEquals(new EpochSecondsContainer(new EpochSeconds(1000)), actual);
+  }
+
+  @Test
+  public void convertToListOfContainerObjectsFromInstanceOfSelf() throws ClassNotFoundException {
+    Map<String, Object> item = new HashMap<>();
+    item.put("seconds", new EpochSeconds(1000));
+
+    List<Map<String, Object>> raw = new ArrayList<>();
+    raw.add(item);
+
+    Object actual = mapper.convert(raw, new GraphQLList(EpochSecondsContainer.GraphQLType));
+
+    List<EpochSecondsContainer> expected = new ArrayList<>();
+    expected.add(new EpochSecondsContainer(new EpochSeconds(1000)));
+    assertEquals(expected, actual);
+  }
+}
+
+class EpochSecondsContainer {
+  public final EpochSeconds seconds;
+
+  public static final GraphQLInputObjectType GraphQLType =
+      GraphQLInputObjectType.newInputObject().name("EpochSecondsContainer").build();
+
+  public EpochSecondsContainer(@JsonProperty("seconds") EpochSeconds seconds) {
+    this.seconds = seconds;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    EpochSecondsContainer that = (EpochSecondsContainer) o;
+
+    return Objects.equals(seconds, that.seconds);
+  }
+
+  @Override
+  public int hashCode() {
+    return seconds != null ? seconds.hashCode() : 0;
+  }
+
+  @Override
+  public String toString() {
+    return "EpochSecondsContainer{" + "seconds=" + seconds + '}';
   }
 }

--- a/src/test/java/com/newrelic/graphql/schema/scalars/MillisecondsTest.java
+++ b/src/test/java/com/newrelic/graphql/schema/scalars/MillisecondsTest.java
@@ -8,12 +8,23 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.newrelic.graphql.mapper.GraphQLInputMapper;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLList;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.junit.Test;
 
 public class MillisecondsTest {
 
   private final Milliseconds millis = new Milliseconds(1L);
+  private final GraphQLInputMapper mapper =
+      new GraphQLInputMapper(this.getClass().getPackage().getName());
 
   @Test
   public void testEquals() {
@@ -37,5 +48,67 @@ public class MillisecondsTest {
   public void floatingPointDuration() {
     Milliseconds floating = new Milliseconds(1.234);
     assertEquals(Duration.ofSeconds(0, 1233999L), floating.getDuration());
+  }
+
+  @Test
+  public void convertToScalarFromInstanceOfSelf() throws ClassNotFoundException {
+    Object actual = mapper.convert(new Milliseconds(1000), PredefinedScalars.Milliseconds);
+
+    assertEquals(new Milliseconds(1000), actual);
+  }
+
+  @Test
+  public void convertToContainerObjectFromInstanceOfSelf() throws ClassNotFoundException {
+    HashMap<String, Object> raw = new HashMap<>();
+    raw.put("millis", new Milliseconds(1000));
+    Object actual = mapper.convert(raw, MillisecondsContainer.GraphQLType);
+
+    assertEquals(new MillisecondsContainer(new Milliseconds(1000)), actual);
+  }
+
+  @Test
+  public void convertToListOfContainerObjectsFromInstanceOfSelf() throws ClassNotFoundException {
+    Map<String, Object> item = new HashMap<>();
+    item.put("millis", new Milliseconds(1000));
+
+    List<Map<String, Object>> raw = new ArrayList<>();
+    raw.add(item);
+
+    Object actual = mapper.convert(raw, new GraphQLList(MillisecondsContainer.GraphQLType));
+
+    List<MillisecondsContainer> expected = new ArrayList<>();
+    expected.add(new MillisecondsContainer(new Milliseconds(1000)));
+    assertEquals(expected, actual);
+  }
+}
+
+class MillisecondsContainer {
+  public final Milliseconds millis;
+
+  public static final GraphQLInputObjectType GraphQLType =
+      GraphQLInputObjectType.newInputObject().name("MillisecondsContainer").build();
+
+  public MillisecondsContainer(@JsonProperty("millis") Milliseconds millis) {
+    this.millis = millis;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    MillisecondsContainer that = (MillisecondsContainer) o;
+
+    return Objects.equals(millis, that.millis);
+  }
+
+  @Override
+  public int hashCode() {
+    return millis != null ? millis.hashCode() : 0;
+  }
+
+  @Override
+  public String toString() {
+    return "MillisecondsContainer{" + "millis=" + millis + '}';
   }
 }

--- a/src/test/java/com/newrelic/graphql/schema/scalars/MinutesTest.java
+++ b/src/test/java/com/newrelic/graphql/schema/scalars/MinutesTest.java
@@ -6,12 +6,23 @@ package com.newrelic.graphql.schema.scalars;
 
 import static org.junit.Assert.*;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.newrelic.graphql.mapper.GraphQLInputMapper;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLList;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.junit.Test;
 
 public class MinutesTest {
 
   private final Minutes minutes = new Minutes(1L);
+  private final GraphQLInputMapper mapper =
+      new GraphQLInputMapper(this.getClass().getPackage().getName());
 
   @Test
   public void testEquals() {
@@ -35,5 +46,67 @@ public class MinutesTest {
   public void floatingPointDurationIgnored() {
     Minutes floating = new Minutes(1.234);
     assertEquals(Duration.ofMinutes(1), floating.getDuration());
+  }
+
+  @Test
+  public void convertToScalarFromInstanceOfSelf() throws ClassNotFoundException {
+    Object actual = mapper.convert(new Minutes(1000), PredefinedScalars.Minutes);
+
+    assertEquals(new Minutes(1000), actual);
+  }
+
+  @Test
+  public void convertToContainerObjectFromInstanceOfSelf() throws ClassNotFoundException {
+    HashMap<String, Object> raw = new HashMap<>();
+    raw.put("minutes", new Minutes(1000));
+    Object actual = mapper.convert(raw, MinutesContainer.GraphQLType);
+
+    assertEquals(new MinutesContainer(new Minutes(1000)), actual);
+  }
+
+  @Test
+  public void convertToListOfContainerObjectsFromInstanceOfSelf() throws ClassNotFoundException {
+    Map<String, Object> item = new HashMap<>();
+    item.put("minutes", new Minutes(1000));
+
+    List<Map<String, Object>> raw = new ArrayList<>();
+    raw.add(item);
+
+    Object actual = mapper.convert(raw, new GraphQLList(MinutesContainer.GraphQLType));
+
+    List<MinutesContainer> expected = new ArrayList<>();
+    expected.add(new MinutesContainer(new Minutes(1000)));
+    assertEquals(expected, actual);
+  }
+}
+
+class MinutesContainer {
+  public final Minutes minutes;
+
+  public static final GraphQLInputObjectType GraphQLType =
+      GraphQLInputObjectType.newInputObject().name("MinutesContainer").build();
+
+  public MinutesContainer(@JsonProperty("minutes") Minutes minutes) {
+    this.minutes = minutes;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    MinutesContainer that = (MinutesContainer) o;
+
+    return Objects.equals(minutes, that.minutes);
+  }
+
+  @Override
+  public int hashCode() {
+    return minutes != null ? minutes.hashCode() : 0;
+  }
+
+  @Override
+  public String toString() {
+    return "MinutesContainer{" + "minutes=" + minutes + '}';
   }
 }

--- a/src/test/java/com/newrelic/graphql/schema/scalars/SecondsTest.java
+++ b/src/test/java/com/newrelic/graphql/schema/scalars/SecondsTest.java
@@ -8,12 +8,23 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.newrelic.graphql.mapper.GraphQLInputMapper;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLList;
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.junit.Test;
 
 public class SecondsTest {
 
   private final Seconds seconds = new Seconds(1L);
+  private final GraphQLInputMapper mapper =
+      new GraphQLInputMapper(this.getClass().getPackage().getName());
 
   @Test
   public void testEquals() {
@@ -37,5 +48,67 @@ public class SecondsTest {
   public void floatingPointDuration() {
     Seconds floating = new Seconds(1.234);
     assertEquals(Duration.ofSeconds(1, 233999999L), floating.getDuration());
+  }
+
+  @Test
+  public void convertToScalarFromInstanceOfSelf() throws ClassNotFoundException {
+    Object actual = mapper.convert(new Seconds(1000), PredefinedScalars.Seconds);
+
+    assertEquals(new Seconds(1000), actual);
+  }
+
+  @Test
+  public void convertToContainerObjectFromInstanceOfSelf() throws ClassNotFoundException {
+    HashMap<String, Object> raw = new HashMap<>();
+    raw.put("seconds", new Seconds(1000));
+    Object actual = mapper.convert(raw, SecondsContainer.GraphQLType);
+
+    assertEquals(new SecondsContainer(new Seconds(1000)), actual);
+  }
+
+  @Test
+  public void convertToListOfContainerObjectsFromInstanceOfSelf() throws ClassNotFoundException {
+    Map<String, Object> item = new HashMap<>();
+    item.put("seconds", new Seconds(1000));
+
+    List<Map<String, Object>> raw = new ArrayList<>();
+    raw.add(item);
+
+    Object actual = mapper.convert(raw, new GraphQLList(SecondsContainer.GraphQLType));
+
+    List<SecondsContainer> expected = new ArrayList<>();
+    expected.add(new SecondsContainer(new Seconds(1000)));
+    assertEquals(expected, actual);
+  }
+}
+
+class SecondsContainer {
+  public final Seconds seconds;
+
+  public static final GraphQLInputObjectType GraphQLType =
+      GraphQLInputObjectType.newInputObject().name("SecondsContainer").build();
+
+  public SecondsContainer(@JsonProperty("seconds") Seconds seconds) {
+    this.seconds = seconds;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    SecondsContainer that = (SecondsContainer) o;
+
+    return Objects.equals(seconds, that.seconds);
+  }
+
+  @Override
+  public int hashCode() {
+    return seconds != null ? seconds.hashCode() : 0;
+  }
+
+  @Override
+  public String toString() {
+    return "SecondsContainer{" + "seconds=" + seconds + '}';
   }
 }


### PR DESCRIPTION
`graphql-java` turns the input scalars into our own wrapper types on the
way in. Sadly, though, our `GraphQLInputMapper` configuration for Jackson
doesn't know how to treat those scalars when constructing objects that
contain them. It ends up breaking down our scalars into a hash, so we
have to handle that incoming property hash to let it deserialize
properly.

This could also be handled via custom deserializers with the object
mapper, but I prefer the approach where the objects themselves have that
responsibility to avoid having to do lots of customization on the
`ObjectMapper` that out `GraphQLInputMapper` uses.