### PR TITLE
Upgrade graphql-java to latest version, 16.2, with accompanying changes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,6 +3,7 @@ val jacksonCoreVersion = project.findProperty("jackson-core.version") as String
 val jacksonDatabindVersion = project.findProperty("jackson-databind.version") as String
 val junitVersion = project.findProperty("junit.version") as String
 val mockitoVersion = project.findProperty("mockito.version") as String
+val slf4jVersion = project.findProperty("slf4j.version") as String
 
 plugins {
     id("java-library")
@@ -24,6 +25,7 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:${jacksonCoreVersion}")
     implementation("com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}")
     implementation("com.graphql-java:graphql-java:${graphqlVersion}")
+    implementation("org.slf4j:slf4j-api:${slf4jVersion}")
 
     testImplementation("junit:junit:${junitVersion}")
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,8 @@ jdk.version=1.8
 #
 jackson-core.version = 2.10.3
 jackson-databind.version = 2.10.3
-graphql.version=12.0
+graphql.version=16.2
+slf4j.version=1.7.30
 
 #
 # test

--- a/src/main/java/com/newrelic/graphql/mapper/GraphQLInputMapper.java
+++ b/src/main/java/com/newrelic/graphql/mapper/GraphQLInputMapper.java
@@ -75,9 +75,13 @@ public class GraphQLInputMapper {
         return mapper.getTypeFactory().constructCollectionType(List.class, innerType);
       }
     } else if (type instanceof GraphQLInputObjectType) {
-      return mapper.getTypeFactory().constructType(classInPackage(packageName, type));
+      return mapper
+          .getTypeFactory()
+          .constructType(classInPackage(packageName, ((GraphQLInputObjectType) type).getName()));
     } else if (type instanceof GraphQLEnumType) {
-      return mapper.getTypeFactory().constructType(classInPackage(packageName, type));
+      return mapper
+          .getTypeFactory()
+          .constructType(classInPackage(packageName, ((GraphQLEnumType) type).getName()));
     } else if (type instanceof GraphQLNonNull) {
       return getType(((GraphQLNonNull) type).getWrappedType());
     }
@@ -85,9 +89,8 @@ public class GraphQLInputMapper {
     return null;
   }
 
-  private Class<?> classInPackage(String packageName, GraphQLType type)
-      throws ClassNotFoundException {
-    String className = String.format("%s.%s", packageName, type.getName());
+  private Class<?> classInPackage(String packageName, String name) throws ClassNotFoundException {
+    String className = String.format("%s.%s", packageName, name);
     return Class.forName(className);
   }
 }

--- a/src/main/java/com/newrelic/graphql/schema/SimpleGraphQLBuilder.java
+++ b/src/main/java/com/newrelic/graphql/schema/SimpleGraphQLBuilder.java
@@ -98,8 +98,7 @@ public class SimpleGraphQLBuilder {
     }
 
     SchemaGenerator schemaGenerator = new SchemaGenerator();
-    SchemaGenerator.Options options =
-        SchemaGenerator.Options.defaultOptions().enforceSchemaDirectives(false);
+    SchemaGenerator.Options options = SchemaGenerator.Options.defaultOptions();
     GraphQLSchema schema =
         schemaGenerator.makeExecutableSchema(options, typeRegistry, runtimeWiringBuilder.build());
 

--- a/src/test/java/com/newrelic/graphql/mapper/GraphQLInputMapperTest.java
+++ b/src/test/java/com/newrelic/graphql/mapper/GraphQLInputMapperTest.java
@@ -8,11 +8,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
 import graphql.Scalars;
-import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLEnumType;
 import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLType;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -183,10 +183,11 @@ public class GraphQLInputMapperTest {
 
   @Test
   public void wrench() {
-    GraphQLDirective unsupportedGraphQLType = GraphQLDirective.newDirective().name("bunk").build();
+    GraphQLType unsupportedGraphQLType =
+        GraphQLInputObjectType.newInputObject().name("bunk").build();
 
     assertThrows(
-        ClassCastException.class,
+        ClassNotFoundException.class,
         () -> {
           // If we don't assign the value the code gets skipped so it's not actually unused!!
           Integer i = 42;


### PR DESCRIPTION
This PR attempts to cover several breaking API changes introduced between graphql-java-12.0 and graphql-java-16.2.