### PR TITLE
Prep 0.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,6 @@ val jacksonCoreVersion = project.findProperty("jackson-core.version") as String
 val jacksonDatabindVersion = project.findProperty("jackson-databind.version") as String
 val junitVersion = project.findProperty("junit.version") as String
 val mockitoVersion = project.findProperty("mockito.version") as String
-val slf4jVersion = project.findProperty("slf4j.version") as String
 
 plugins {
     id("java-library")
@@ -25,7 +24,6 @@ dependencies {
     implementation("com.fasterxml.jackson.core:jackson-core:${jacksonCoreVersion}")
     implementation("com.fasterxml.jackson.core:jackson-databind:${jacksonDatabindVersion}")
     implementation("com.graphql-java:graphql-java:${graphqlVersion}")
-    implementation("org.slf4j:slf4j-api:${slf4jVersion}")
 
     testImplementation("junit:junit:${junitVersion}")
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,7 +13,6 @@ jdk.version=1.8
 jackson-core.version = 2.10.3
 jackson-databind.version = 2.10.3
 graphql.version=16.2
-slf4j.version=1.7.30
 
 #
 # test

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.newrelic.graphql
-version = 0.1.1
+version = 0.2.0-SNAPSHOT
 
 jdk.version=1.8
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,5 +17,5 @@ graphql.version=16.2
 #
 # test
 #
-junit.version = 4.13
-mockito.version = 3.3.3
+junit.version = 4.13.2
+mockito.version = 3.9.0

--- a/src/main/java/com/newrelic/graphql/schema/SimpleGraphQLBuilder.java
+++ b/src/main/java/com/newrelic/graphql/schema/SimpleGraphQLBuilder.java
@@ -25,8 +25,6 @@ import graphql.schema.idl.TypeDefinitionRegistry;
 import java.io.Reader;
 import java.util.HashMap;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This builder provides a simple fluent interface for wiring up your schema for runtime execution.
@@ -52,8 +50,6 @@ import org.slf4j.LoggerFactory;
  * </pre>
  */
 public class SimpleGraphQLBuilder {
-  static Logger logger = LoggerFactory.getLogger(SimpleGraphQLBuilder.class);
-
   private static final SchemaParser schemaParser = new SchemaParser();
   private static final DefaultTypeResolver defaultTypeResolver = new DefaultTypeResolver();
 
@@ -211,8 +207,6 @@ public class SimpleGraphQLBuilder {
           String[] parts = key.split("[.]");
           if (parts.length == 2) {
             builder.type(parts[0], t -> t.dataFetcher(parts[1], fetcher));
-          } else {
-            logger.warn("Unexpected field specification '{}'", key);
           }
         });
   }

--- a/src/test/java/com/newrelic/graphql/mapper/GraphQLInputMapperTest.java
+++ b/src/test/java/com/newrelic/graphql/mapper/GraphQLInputMapperTest.java
@@ -13,8 +13,6 @@ import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLType;
-import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -44,16 +42,6 @@ public class GraphQLInputMapperTest {
     assertEquals(Double.valueOf(31.4), mapper.convert(31.4, Scalars.GraphQLFloat));
     assertEquals(true, mapper.convert(true, Scalars.GraphQLBoolean));
     assertEquals("", mapper.convert("", Scalars.GraphQLID));
-    assertEquals(Long.valueOf(1000), mapper.convert((long) 1000, Scalars.GraphQLLong));
-    assertEquals(Short.valueOf((short) 4), mapper.convert((short) 4, Scalars.GraphQLShort));
-    assertEquals(Byte.valueOf((byte) 2), mapper.convert((byte) 2, Scalars.GraphQLByte));
-    assertEquals(
-        BigInteger.valueOf(2000),
-        mapper.convert(BigInteger.valueOf(2000), Scalars.GraphQLBigInteger));
-    assertEquals(
-        BigDecimal.valueOf(3000),
-        mapper.convert(BigDecimal.valueOf(3000), Scalars.GraphQLBigDecimal));
-    assertEquals(Character.valueOf('j'), mapper.convert('j', Scalars.GraphQLChar));
   }
 
   @Test

--- a/src/test/java/com/newrelic/graphql/schema/SimpleGraphQLBuilderTest.java
+++ b/src/test/java/com/newrelic/graphql/schema/SimpleGraphQLBuilderTest.java
@@ -9,10 +9,6 @@ import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 
 import com.newrelic.graphql.schema.scalars.EpochMilliseconds;
 import com.newrelic.graphql.schema.scalars.EpochSeconds;
@@ -40,10 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
-import org.slf4j.Logger;
 
 public class SimpleGraphQLBuilderTest {
 
@@ -68,19 +61,6 @@ public class SimpleGraphQLBuilderTest {
               + "union MyUnion = MyObject | AnotherObject "
               + "type Query { read: MyUnion  list: [MyUnion] }");
 
-  // Some of our tests mess with the logger so hang onto it for our protection in other tests...
-  private Logger savedLogger;
-
-  @Before
-  public void setup() {
-    savedLogger = SimpleGraphQLBuilder.logger;
-  }
-
-  @After
-  public void teardown() {
-    SimpleGraphQLBuilder.logger = savedLogger;
-  }
-
   @Test
   public void buildWithFetcherMap() {
     DataFetcher fetcher = env -> "yup";
@@ -102,30 +82,6 @@ public class SimpleGraphQLBuilderTest {
 
     ExecutionResult response = graphQL.execute("query { read }");
     assertThat(response.getData(), is(expectedResponse("read", "yup")));
-  }
-
-  @Test
-  public void warnsOnTooManyPartsInFieldSpecification() {
-    SimpleGraphQLBuilder.logger = mock(Logger.class);
-
-    Map<String, DataFetcher> fetchers = new HashMap<>();
-    fetchers.put("Query.read.too.many.dots", env -> "yup");
-
-    new SimpleGraphQLBuilder(schema).fetchers(fetchers).build();
-
-    verify(SimpleGraphQLBuilder.logger).warn(anyString(), contains("Query.read.too.many.dots"));
-  }
-
-  @Test
-  public void warnsOnTooFewPartsInFieldSpecification() {
-    SimpleGraphQLBuilder.logger = mock(Logger.class);
-
-    Map<String, DataFetcher> fetchers = new HashMap<>();
-    fetchers.put("Query", env -> "yup");
-
-    new SimpleGraphQLBuilder(schema).fetchers(fetchers).build();
-
-    verify(SimpleGraphQLBuilder.logger).warn(anyString(), contains("Query"));
   }
 
   @Test


### PR DESCRIPTION
This will be the release with 16.x `graphql-java` compatibility.

In addition to the library bump from #22 this tidies a few things:

* We were pulling in a logging library for one usage of it which we should just stop
* 16.x deprecated some non-standard scalars types that we had explicit tests against. If they're deprecated, we shouldn't bother testing them here.