### PR TITLE
Cut 0.2.0 release

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.newrelic.graphql
-version = 0.2.0-SNAPSHOT
+version = 0.2.0
 
 jdk.version=1.8
 


### PR DESCRIPTION
Current Actions setup doesn't publish SNAPSHOT anyway, so let's get it rolling.