### PR TITLE
Fix for scalars missing description from SDL

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.newrelic.graphql
-version = 0.2.0
+version = 0.2.1
 
 jdk.version=1.8
 


### PR DESCRIPTION
The builder work around scalars to see which are registered and provide defaults meant that we could lose the description from the SDL type. Make sure that comes through.