### PR TITLE
Upgrade graphql-java to 20.0, with accompanying changes

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ jdk.version=1.8
 #
 jackson-core.version = 2.10.3
 jackson-databind.version = 2.10.3
-graphql.version=16.2
+graphql.version=20.0
 
 #
 # test


### PR DESCRIPTION
Upgrades to a more recent version of graphql. There are breaking changes in 20, but this looks to be safe for now. This version bump adds the ability to deprecate input fields.