### PR TITLE
Fix CHANGELOG, extend timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix for scalar descriptions missing from SDL [#25](https://github.com/newrelic/newrelic-graphql-java-core/pull/25)
 
 ## [0.2.0] - 2023-01-26
-- Update to `graphql-java` 20.0 [#27](https://github.com/newrelic/newrelic-graphql-java-core/pull/27)
+- Move to `graphql-java` version 16.2 [#22](https://github.com/newrelic/newrelic-graphql-java-core/pull/22), [#23](https://github.com/newrelic/newrelic-graphql-java-core/pull/23)
 
 ## [0.1.1] - 2020-06-30
 - Fix for using our scalars with input mapped object [#17](https://github.com/newrelic/newrelic-graphql-java-core/pull/17)

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,10 @@ version = 0.3.0
 
 jdk.version=1.8
 
+# Increase timeout when pushing to Sonatype (otherwise we get timeouts)
+# Borrowed from https://github.com/nisrulz/zentone/pull/28
+systemProp.org.gradle.internal.http.socketTimeout=120000
+
 #
 # build
 #


### PR DESCRIPTION
Publish is dying with timeouts

```
* What went wrong:
Execution failed for task ':publishMavenJavaPublicationToMavenRepository'.
> Failed to publish publication 'mavenJava' to repository 'maven'
   > Could not write to resource 'https://oss.sonatype.org/service/local/staging/deploy/maven2/com/newrelic/graphql/core/0.3.0/core-0.3.0.jar'.
      > Read timed out
```

Staging repos do eventually show up in UI, so I'm hopeful that a longer timeout as set here will get through