### PR TITLE
Bump for CVE-2023-28867

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 group = com.newrelic.graphql
-version = 0.3.0
+version = 0.3.1
 
 jdk.version=1.8
 
@@ -16,7 +16,7 @@ systemProp.org.gradle.internal.http.socketTimeout=120000
 #
 jackson-core.version = 2.10.3
 jackson-databind.version = 2.10.3
-graphql.version=20.0
+graphql.version=20.1
 
 #
 # test


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2023-28867

Even though this is awaiting assessment, graphql-java has apparently rev'ed and published several new point-releases for this fix, so it seems ... important.