### PR TITLE
Submit dependencies on merge to master

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+
     - name: Build and Publish
       env:
         SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
@@ -23,6 +24,10 @@ jobs:
         ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.SIGNING_KEY_ID }}
         ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.SIGNING_PASSWORD }}
       run: ./gradlew build publish
+
+    - name: Run dependency snapshot
+      uses: newrelic-forks/gradle-dependency-submission@v1
+
     - name: Archive libs
       uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,8 +15,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
     - name: Build and Publish
       env:
         SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,8 +15,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
     - name: Build with Gradle
       run: ./gradlew build javadoc
     - name: Archive libs

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,8 +15,10 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+
     - name: Build with Gradle
       run: ./gradlew build javadoc
+
     - name: Archive libs
       uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
This enables running the https://github.com/newrelic-forks/gradle-dependency-submission GitHub action on merge to master. We only bother on master because of this note from the README:

> ℹ️ Currently the action has to be run on the default branch. Running it as part of a PR won't update the [Dependency graph](https://github.com/mikepenz/gradle-dependency-submission/network/dependencies) of your projects [Insights](https://github.com/mikepenz/gradle-dependency-submission/pulse) - This seems to be a GitHub requirement.

I did run it through once on [the PR build here](https://github.com/newrelic/newrelic-graphql-java-core/actions/runs/5351164214/jobs/9704661854?pr=35) before removing it. The output looked promisingly correct:

```
Run newrelic-forks/gradle-dependency-submission@v1
📘 Reading input values
🔨 Processing gradle dependencies for root module - ':'
📄 Parsing gradle dependencies graph - ':'
  
📦️ Preparing Dependency Snapshot - ':'
Notice: Submitting snapshot...
Notice: {
    "detector": {
        "name": "mikepenz/gradle-dependency-submission",
        "url": "https://github.com/mikepenz/gradle-dependency-submission",
        "version": "0.8.2"
    },
    "version": 0,
    "job": {
        "correlator": "build-:-",
        "id": "5351164214"
    },
    "sha": "a9e0cd3c2fff625eb54d31a962e08ee215c7d75e",
    "ref": "refs/pull/35/merge",
    "scanned": "2023-06-22T23:13:08.[12](https://github.com/newrelic/newrelic-graphql-java-core/actions/runs/5351164214/jobs/9704661854?pr=35#step:5:13)8Z",
    "manifests": {
        "core": {
            "resolved": {
                "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.10.3": {
                    "package_url": "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.10.3",
                    "relationship": "direct",
                    "dependencies": []
                },
                "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.10.3": {
                    "package_url": "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.10.3",
                    "relationship": "direct",
                    "dependencies": [
                        "pkg:maven/com.fasterxml.jackson.core/jackson-annotations@2.10.3",
                        "pkg:maven/com.fasterxml.jackson.core/jackson-core@2.10.3"
                    ]
                },
                "pkg:maven/com.graphql-java/graphql-java@20.1": {
                    "package_url": "pkg:maven/com.graphql-java/graphql-java@20.1",
                    "relationship": "direct",
                    "dependencies": [
                        "pkg:maven/com.graphql-java/java-dataloader@3.2.0",
                        "pkg:maven/org.reactivestreams/reactive-streams@1.0.3",
                        "pkg:maven/org.slf4j/slf4j-api@1.7.[35](https://github.com/newrelic/newrelic-graphql-java-core/actions/runs/5351164214/jobs/9704661854?pr=35#step:5:40)"
                    ]
                },
```

Will have to merge fully to see it actually happen for master but 🤞 